### PR TITLE
Delete state handler inside of trace branch component

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,42 +24,68 @@ To use `react-nested-tree2` in your project, import the `TreeRoot` component and
 import React from "react";
 import { TreeRoot } from "react-nested-tree2";
 
-const App = () => {
+function App() {
+  const [treeData, setTreeData] = useState({
+    id: "root",
+    children: [
+      {
+        id: 1,
+        data: { name: "* Branch 1" },
+        folder_id: "root",
+        children: [
+          { id: 2, folder_id: 1, data: { name: "- Leaf 1-1" } },
+          { id: 3, folder_id: 1, data: { name: "- Leaf 1-2" } },
+          {
+            id: 4,
+            folder_id: 1,
+            data: { name: "* Branch 1-4" },
+            children: [{ id: 5, folder_id: 4, data: { name: "- Leaf 1-4-1" } }],
+            isToggled: false,
+          },
+        ],
+        isToggled: false,
+      },
+      {
+        id: 6,
+        data: { name: "* Branch 2" },
+        folder_id: "root",
+        children: [{ id: 7, folder_id: 2, data: { name: "- Leaf 2-1" } }],
+        isToggled: false,
+      },
+    ],
+  });
+
+  // Handler example from parent that gets a branchId.
+  function handleOnBranchToggle(branchId: string | number) {
+    const treeDataCopy = { ...treeData };
+    const treeDataById = getTreeDataById({ tree: treeDataCopy, id: branchId });
+    if (treeDataById && treeDataById.hasOwnProperty("isToggled")) {
+      treeDataById.isToggled = !treeDataById.isToggled;
+    }
+    setTreeData(treeDataCopy);
+  }
+
   return (
     <TreeRoot<{ name: string }, { name: string }>
       style={{ marginLeft: "20px" }}
-      data={{
-        id: "root",
-        children: [
-          {
-            id: 1,
-            data: { name: "* Branch 1" },
-            children: [
-              { id: 2, data: { name: "- Leaf 1-1" } },
-              { id: 3, data: { name: "- Leaf 1-2" } },
-              {
-                id: 4,
-                data: { name: "* Branch 1-4" },
-                children: [{ id: 5, data: { name: "- Leaf 1-4-1" } }],
-              },
-            ],
-          },
-          {
-            id: 2,
-            data: { name: "* Branch 2" },
-            children: [{ id: 5, data: { name: "- Leaf 2-1" } }],
-          },
-        ],
-      }}
+      data={treeData}
       renderLeaf={(leaf) => {
         return <p>{leaf.name}</p>;
       }}
-      renderBranch={(branch, _isToggled, onToggle) => {
-        return <button onClick={onToggle}>{branch.name}</button>;
+      renderBranch={(branch) => {
+        return (
+          <div onClick={() => handleOnBranchToggle(branch.id)}>
+            {branch.isToggled ? (
+              <p>{branch.data?.name}</p>
+            ) : (
+              <p>branch is closed</p>
+            )}
+          </div>
+        );
       }}
     />
   );
-};
+}
 
 export default App;
 ```

--- a/src/tree-branch.tsx
+++ b/src/tree-branch.tsx
@@ -1,10 +1,4 @@
-import React, {
-  HTMLAttributes,
-  PropsWithChildren,
-  ReactNode,
-  useCallback,
-  useState,
-} from 'react';
+import React, {HTMLAttributes, PropsWithChildren, ReactNode} from 'react';
 import type {TreeRootProps} from './tree-root';
 import {TreeRoot} from './tree-root';
 import {isBranchType} from './utils/is-branch-type';
@@ -23,20 +17,10 @@ export function TreeBranch<BranchType, LeafType>({
   rootProps,
   ...liProps
 }: TreeBranchProps<BranchType, LeafType>): ReactNode {
-  const [isToggledState, setIsToggledState] = useState<boolean>(false);
-
-  const onToggleCallback = useCallback(() => {
-    setIsToggledState(!isToggledState);
-  }, [isToggledState]);
-
   return (
     <li key={data.id} {...liProps}>
-      <div>
-        {data.data &&
-          isBranchType(data) &&
-          renderBranch(data.data, isToggledState, onToggleCallback)}
-      </div>
-      <span className={`${isToggledState ? 'block' : 'hidden'}`}>
+      <div>{data.data && isBranchType(data) && renderBranch(data)}</div>
+      <span className={`${data.isToggled ? 'block' : 'hidden'}`}>
         <TreeRoot
           data={data}
           depth={depth}

--- a/src/tree-data.ts
+++ b/src/tree-data.ts
@@ -1,5 +1,6 @@
 export type TreeData<BranchData, LeafData> = {
   id: string | number;
+  isToggled?: boolean;
   data?: BranchData | LeafData;
   children?: TreeData<BranchData, LeafData>[];
 };

--- a/src/tree-root.tsx
+++ b/src/tree-root.tsx
@@ -14,11 +14,7 @@ export type TreeRootProps<BranchType, LeafType> =
     data: TreeData<BranchType, LeafType>;
     depth?: number;
     renderLeaf: (item: LeafType) => ReactNode;
-    renderBranch: (
-      item: BranchType,
-      isToggled: boolean,
-      onToggle: () => void,
-    ) => ReactNode;
+    renderBranch: (item: TreeData<BranchType, LeafType>) => ReactNode;
   };
 
 export function TreeRoot<BranchType, LeafType>({


### PR DESCRIPTION
This PR deletes the state that controls the open / close functionality from `tree-branch`. With this, the library lets the parent to handle the branch state by passing the branch object to it. 

This video shows the working example that's added on the `README` file.


https://github.com/user-attachments/assets/c710ff17-1544-4294-b424-0bf73f8654a9

